### PR TITLE
adds keyboard event listener for playback controls

### DIFF
--- a/src/components/app/controls/main-controls/index.jsx
+++ b/src/components/app/controls/main-controls/index.jsx
@@ -1,16 +1,30 @@
-import React from 'react';
-import propTypes from 'prop-types';
 import {
   faPlay,
-  faStop,
-  faStepForward,
-  faStepBackward,
   faRandom,
+  faStepBackward,
+  faStepForward,
+  faStop,
 } from '@fortawesome/free-solid-svg-icons';
+import propTypes from 'prop-types';
+import React, { useEffect } from 'react';
 import { isMobile } from 'react-device-detect';
 import ControlButtonComponent from '../control-button';
 import ButtonSpacerComponent from './button-spacer';
 import './main-controls.scss';
+
+function useKeyboardEvent(key, callback) {
+  useEffect(() => {
+    const handler = event => {
+      if (event.key === key) {
+        callback();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  },[callback]);
+}
 
 const makePrimaryButton = (faIcon, onClick) =>
   function PrimaryButtonComponent() {
@@ -36,6 +50,9 @@ const MainControlsComponent = ({
   const PrimaryButtonComponent = isPlaying
     ? makePrimaryButton(faStop, onStopClick)
     : makePrimaryButton(faPlay, onPlayClick);
+  useKeyboardEvent(' ', isPlaying ? onStopClick : onPlayClick);
+  useKeyboardEvent('ArrowLeft', onPreviousClick);
+  useKeyboardEvent('ArrowRight', onNextClick);
   return (
     <div className="main-controls">
       {!isMobile && <ButtonSpacerComponent />}


### PR DESCRIPTION
New to contributing to open source, so let me know if I've done something wrong.

This adds a keyboard event listener hook that will listen for spacebar, arrow left, and arrow right to pause/play, previous, and next track respectively.

I noticed we are using a version of React above 16.8, so hooks should be supported, but wasn't sure if they were desired from a code style standpoint.