### PR TITLE
v1.16.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (none)
 
+## [1.16.1] - 2019-10-18
+
+### Fixed
+
+- Fix global stats daily refresh
+
 ## [1.16.0] - 2019-10-13
 
 ### Changed
@@ -537,7 +543,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sound files will no longer be fetched and cached during service worker installation. They'll be cached once they are fetched for the first time. This significantly reduces cache usage since only one audio format is used per client.
 
-[unreleased]: https://github.com/generative-music/generative.fm/compare/v1.16.0...HEAD
+[unreleased]: https://github.com/generative-music/generative.fm/compare/v1.16.1...HEAD
+[1.16.1]: https://github.com/generative-music/generative.fm/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/generative-music/generative.fm/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/generative-music/generative.fm/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/generative-music/generative.fm/compare/v1.13.0...v1.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generative.fm",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generative.fm",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "A platform for playing generative music in the browser",
   "main": "index.js",
   "scripts": {

--- a/src/store/middleware/fetch-stats.middleware.js
+++ b/src/store/middleware/fetch-stats.middleware.js
@@ -9,6 +9,8 @@ import pipe from '@utils/pipe';
 const lastPlayTimeFetchKey = 'LAST_PLAY_TIME_FETCH';
 const lastFavoriteCountFetchKey = 'LAST_FAVORITE_COUNT_FETCH';
 
+const getTimeStampFromLocalStorage = key => Number(localStorage.getItem(key));
+
 const fetchStatsMiddleware = store => next => action => {
   const result = next(action);
   let playTimeFetching = false;
@@ -18,8 +20,8 @@ const fetchStatsMiddleware = store => next => action => {
 
   if (isProduction && isOnline()) {
     if (sorting.key === 'globalPlayTime' || sorting.key === 'trending') {
-      const lastPlayTimeFetch = new Date(
-        localStorage.getItem(lastPlayTimeFetchKey)
+      const lastPlayTimeFetch = getTimeStampFromLocalStorage(
+        lastPlayTimeFetchKey
       );
       if (
         !playTimeFetching &&
@@ -43,8 +45,8 @@ const fetchStatsMiddleware = store => next => action => {
           });
       }
     } else if (sorting.key === 'favoriteCount') {
-      const lastFavoriteCountFetch = new Date(
-        localStorage.getItem(lastFavoriteCountFetchKey)
+      const lastFavoriteCountFetch = getTimeStampFromLocalStorage(
+        lastFavoriteCountFetchKey
       );
       if (
         !favoriteCountFetching &&


### PR DESCRIPTION
### Fixed

- Fix global stats daily refresh

The new sortings based on global data (global play time, global favorites, trending) require the stats to be updated, which is supposed to happen every day.
